### PR TITLE
Keychain hotfix

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -72,6 +72,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	new/datum/stack_recipe("meatspike frame", /obj/structure/kitchenspike_frame, 5, time = 25, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("reflector frame", /obj/structure/reflector, 5, time = 25, one_per_turf = TRUE, on_floor = TRUE), \
 	null, \
+	new/datum/stack_recipe("grenade casing", /obj/item/grenade/chem_grenade), \
 	new/datum/stack_recipe("light fixture frame", /obj/item/wallframe/light_fixture, 2), \
 	new/datum/stack_recipe("small light fixture frame", /obj/item/wallframe/light_fixture/small, 1), \
 	null, \

--- a/code/modules/fallout/obj/door_keys.dm
+++ b/code/modules/fallout/obj/door_keys.dm
@@ -70,7 +70,10 @@
 	STR.max_combined_w_class = 35
 
 /obj/item/storage/keys_set/update_icon()
-	icon_state = "keychain_[contents.len]"
+	if(contents.len <= 4)
+		icon_state = "keychain_[contents.len]"
+	else
+		icon_state = "keychain_4"
 
 /obj/item/storage/keys_set/proc/get_key_with_id(id)
 	for(var/obj/item/door_key/K in contents)

--- a/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -273,3 +273,7 @@
 	list_reagents = list("nutriment" = 5)
 	bonus_reagents = list("nutriment" = 1, "vitamin" = 1)
 	tastes = list("butter", "exotic butter")
+
+/obj/item/reagent_containers/food/snacks/butterdog/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/slippery, 80)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -8,6 +8,7 @@
 	icon_state = "detective"
 	item_state = "gun"
 	flags_1 =  CONDUCT_1
+	slot_flags = ITEM_SLOT_BELT
 	materials = list(MAT_METAL=2000)
 	w_class = WEIGHT_CLASS_NORMAL
 	throwforce = 5

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -8,7 +8,6 @@
 	burst_size = 1
 	fire_delay = 0
 	actions_types = list()
-	slot_flags = ITEM_SLOT_BELT
 
 /obj/item/gun/ballistic/automatic/pistol/update_icon()
 	..()

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -5,7 +5,6 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder
 	casing_ejector = FALSE
 	w_class = WEIGHT_CLASS_NORMAL
-	slot_flags = ITEM_SLOT_BELT
 
 /obj/item/gun/ballistic/revolver/Initialize()
 	. = ..()

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -169,7 +169,6 @@
 	fire_delay = 2
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/pistol)
 	cell_type = /obj/item/stock_parts/cell/ammo/ec
-	slot_flags = ITEM_SLOT_BELT
 
 /obj/item/gun/energy/laser/scatter
 	name = "tribeam laser rifle"
@@ -211,7 +210,6 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	weapon_weight = WEAPON_LIGHT
 	cell_type = /obj/item/stock_parts/cell/ammo/ec
-	slot_flags = ITEM_SLOT_BELT
 
 
 //projectiles


### PR DESCRIPTION
 ## Description
 added if/else check for if a keychain had over 4 keys. If it did it just uses the sprite for 4 keys.
 
 ## Motivation and Context
 Bug was reported.
 
 ## How Has This Been Tested?
 Hosted locally, spawned in Kebob, gave myself 10 metal, crafted keychain and 9 keys. Sprite did not disappear and the keychain filled up at 7 keys
 
 ## Screenshots (if appropriate):
 ![image](https://user-images.githubusercontent.com/19897580/65372618-d7400880-dcb5-11e9-90cd-907a81a40ec9.png)
 
 ## Changelog (necessary)
 🆑
 fix: fixes keychains disappearing
 code: changed some code
 /🆑